### PR TITLE
Remove incorrect repos

### DIFF
--- a/main.py
+++ b/main.py
@@ -95,7 +95,6 @@ repos = [
     'alphagov/static',
     'alphagov/support',
     'alphagov/support-api',
-    'alphagov/tech-docs-monitor',
     'alphagov/transition',
     'alphagov/transition-config',
     'alphagov/travel-advice-publisher',

--- a/main.py
+++ b/main.py
@@ -49,7 +49,6 @@ repos = [
     'alphagov/govuk-docker',
     'alphagov/govuk-pact-broker',
     'alphagov/govuk-puppet',
-    'alphagov/govuk-schemas',
     'alphagov/govuk-secrets',
     'alphagov/govuk-saas-config',
     'alphagov/govuk-user-reviewer',


### PR DESCRIPTION
'govuk-schemas' is not a repo. It really means 'govuk-content-schemas', but this is already on the repos list.

Also removes 'tech-docs-monitor' from the repos list, as it is not a GOV.UK repo. Attempting to run the upgrade task against a non-GOV.UK-owned repo results in a 404 error.